### PR TITLE
workflows to run from and update no-kmod branch

### DIFF
--- a/.github/workflows/amzn1.yml
+++ b/.github/workflows/amzn1.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Check out BTFHub
         uses: actions/checkout@v3
         with:
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           submodules: 'recursive'
 
@@ -80,6 +81,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: DataDog/btfhub-archive
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           path: archive
           sparse-checkout: |

--- a/.github/workflows/amzn2.yml
+++ b/.github/workflows/amzn2.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Check out BTFHub
         uses: actions/checkout@v3
         with:
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           submodules: 'recursive'
 
@@ -65,6 +66,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: DataDog/btfhub-archive
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           path: archive
           sparse-checkout: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,6 +25,7 @@ jobs:
       - name: checkout btfhub
         uses: actions/checkout@v3
         with:
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           submodules: 'recursive'
 
@@ -49,6 +50,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: DataDog/btfhub-archive
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           path: archive
           sparse-checkout: |

--- a/.github/workflows/rhel7.yml
+++ b/.github/workflows/rhel7.yml
@@ -50,6 +50,7 @@ jobs:
       - name: checkout btfhub
         uses: actions/checkout@v3
         with:
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           submodules: 'recursive'
 
@@ -94,6 +95,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: DataDog/btfhub-archive
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           path: archive
           sparse-checkout: |

--- a/.github/workflows/rhel8.yml
+++ b/.github/workflows/rhel8.yml
@@ -25,6 +25,7 @@ jobs:
       - name: checkout btfhub
         uses: actions/checkout@v3
         with:
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           submodules: 'recursive'
 
@@ -32,6 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: DataDog/btfhub-archive
+          ref: no-kmod
           token: ${{ secrets.DD_BTFHUB_BOT_GITHUB_TOKEN }}
           path: archive
           sparse-checkout: |


### PR DESCRIPTION
This is so we can update to kernel modules and prevent causing problems to CI which still expects no kernel module tarballs.