### PR TITLE
use directory names as releases

### DIFF
--- a/.github/workflows/amzn1.yml
+++ b/.github/workflows/amzn1.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           SCRIPT: |
             set -ex
-            ./btfhub -workers 6 -d amzn -r 1 -a x86_64
+            ./btfhub -workers 6 -d amzn -r 2018 -a x86_64
         run: docker exec -w /workspace $CONTAINER_NAME bash -c "$SCRIPT"
 
       - name: commit and push to btfhub-archive

--- a/cmd/btfhub/commands/generate.go
+++ b/cmd/btfhub/commands/generate.go
@@ -18,13 +18,13 @@ import (
 var possibleArchs = []string{"x86_64", "arm64"}
 
 var distroReleases = map[string][]string{
-	"ubuntu":        {"xenial", "bionic", "focal"},
-	"debian":        {"stretch", "buster"},
+	"ubuntu":        {"16.04", "18.04", "20.04"},
+	"debian":        {"9", "10"},
 	"fedora":        {"24", "25", "26", "27", "28", "29", "30", "31"},
 	"centos":        {"7", "8"},
 	"ol":            {"7", "8"},
 	"rhel":          {"7", "8"},
-	"amzn":          {"1", "2"},
+	"amzn":          {"2018", "2"},
 	"sles":          {"12.3", "12.4", "12.5", "15.0", "15.1", "15.2", "15.3"},
 	"opensuse-leap": {"15.0", "15.1", "15.2", "15.3"},
 }
@@ -32,14 +32,14 @@ var distroReleases = map[string][]string{
 var defaultDistros = []string{"ubuntu", "debian", "fedora", "centos", "ol"}
 
 var defaultReleases = map[string][]string{
-	"ubuntu": {"xenial", "bionic", "focal"},
-	// no stretch for debian
-	"debian":        {"buster"},
+	"ubuntu": {"16.04", "18.04", "20.04"},
+	// no 9/stretch for debian
+	"debian":        {"10"},
 	"fedora":        {"24", "25", "26", "27", "28", "29", "30", "31"},
 	"centos":        {"7", "8"},
 	"ol":            {"7", "8"},
 	"rhel":          {"7", "8"},
-	"amzn":          {"1", "2"},
+	"amzn":          {"2018", "2"},
 	"sles":          {"12.3", "12.4", "12.5", "15.0", "15.1", "15.2", "15.3"},
 	"opensuse-leap": {"15.0", "15.1", "15.2", "15.3"},
 }
@@ -100,7 +100,7 @@ func Generate(ctx context.Context) error {
 				arch := a
 				distro := d
 				produce.Go(func() error {
-					// workDir example: ./archive/ubuntu/focal/x86_64
+					// workDir example: ./archive/ubuntu/20.04/x86_64
 					workDir := filepath.Join(archiveDir, distro, release, arch)
 					if err := os.MkdirAll(workDir, 0775); err != nil {
 						return fmt.Errorf("arch dir: %s", err)

--- a/pkg/pkg/ubuntu.go
+++ b/pkg/pkg/ubuntu.go
@@ -28,6 +28,7 @@ type UbuntuPackage struct {
 	URL           string
 	Size          uint64
 	Release       string
+	ReleaseName   string
 	Flavor        string // generic, gcp, aws, azure
 }
 
@@ -179,7 +180,7 @@ func (pkg *UbuntuPackage) pullLaunchpadDdeb(ctx context.Context, dir string, des
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	cmd := exec.CommandContext(ctx, "pull-lp-ddebs", "-s", "Published", "-s", "Pending", "-s", "Deleted", "-s", "Superseded", "--arch", pkg.Architecture, pkg.Name, pkg.Release)
+	cmd := exec.CommandContext(ctx, "pull-lp-ddebs", "-s", "Published", "-s", "Pending", "-s", "Deleted", "-s", "Superseded", "--arch", pkg.Architecture, pkg.Name, pkg.ReleaseName)
 	cmd.Dir = dir
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/pkg/pkg/utils.go
+++ b/pkg/pkg/utils.go
@@ -65,15 +65,15 @@ func yumDownload(ctx context.Context, pkg string, arch string, destdir string) e
 //
 
 // GetPackageList downloads the Packages.xz file from the given repo and release
-func GetPackageList(ctx context.Context, repo string, release string, arch string) (
+func GetPackageList(ctx context.Context, repo string, releaseName string, arch string) (
 	*bytes.Buffer, error,
 ) {
 	var err error
 	rawPkgs := &bytes.Buffer{}
 
-	main := fmt.Sprintf("%s/dists/%s/main/binary-%s/Packages.xz", repo, release, arch)
-	updates := fmt.Sprintf("%s/dists/%s-updates/main/binary-%s/Packages.xz", repo, release, arch)
-	universe := fmt.Sprintf("%s/dists/%s-updates/universe/binary-%s/Packages.xz", repo, release, arch)
+	main := fmt.Sprintf("%s/dists/%s/main/binary-%s/Packages.xz", repo, releaseName, arch)
+	updates := fmt.Sprintf("%s/dists/%s-updates/main/binary-%s/Packages.xz", repo, releaseName, arch)
+	universe := fmt.Sprintf("%s/dists/%s-updates/universe/binary-%s/Packages.xz", repo, releaseName, arch)
 
 	if err = utils.Download(ctx, main, rawPkgs); err != nil {
 		return nil, fmt.Errorf("download base package list: %s", err)
@@ -88,12 +88,12 @@ func GetPackageList(ctx context.Context, repo string, release string, arch strin
 	return rawPkgs, nil
 }
 
-func ParseAPTPackages(rawPkgs io.Reader, repoURL string, release string) (
+func ParseAPTPackages(rawPkgs io.Reader, repoURL string, release string, releaseName string) (
 	[]*UbuntuPackage, error,
 ) {
 	var kernelPkgs []*UbuntuPackage
 
-	pkg := &UbuntuPackage{Release: release}
+	pkg := &UbuntuPackage{Release: release, ReleaseName: releaseName}
 
 	bio := bufio.NewScanner(rawPkgs)
 	bio.Buffer(make([]byte, 4096), 128*1024)
@@ -107,7 +107,7 @@ func ParseAPTPackages(rawPkgs io.Reader, repoURL string, release string) (
 			if strings.HasPrefix(pkg.Name, "linux-image-") && pkg.isValid() {
 				kernelPkgs = append(kernelPkgs, pkg) // save the previous kernel package
 			}
-			pkg = &UbuntuPackage{Release: release}
+			pkg = &UbuntuPackage{Release: release, ReleaseName: releaseName}
 			continue
 		}
 		if line[0] == ' ' {

--- a/pkg/repo/launchpad.go
+++ b/pkg/repo/launchpad.go
@@ -64,9 +64,9 @@ type lpPublishedBinary struct {
 	BuildLink            string    `json:"build_link"`
 }
 
-func getLaunchpadPackages(ctx context.Context, release string, arch string) ([]*pkg.UbuntuPackage, error) {
+func getLaunchpadPackages(ctx context.Context, release string, releaseName string, arch string) ([]*pkg.UbuntuPackage, error) {
 	name := "linux-image-"
-	distroArchSeries := fmt.Sprintf("https://api.launchpad.net/devel/ubuntu/%s/%s", release, arch)
+	distroArchSeries := fmt.Sprintf("https://api.launchpad.net/devel/ubuntu/%s/%s", releaseName, arch)
 	url := fmt.Sprintf("https://api.launchpad.net/devel/ubuntu/+archive/primary?ws.op=getPublishedBinaries&binary_name=%s&distro_arch_series=%s&ws.size=300", name, distroArchSeries)
 
 	pkgMap := make(map[string]lpPublishedBinary)
@@ -119,6 +119,7 @@ func getLaunchpadPackages(ctx context.Context, release string, arch string) ([]*
 			URL:           url,
 			Size:          math.MaxUint64, // no idea on real size
 			Release:       release,
+			ReleaseName:   releaseName,
 			Flavor:        "",
 		}
 		pkgs = append(pkgs, up)


### PR DESCRIPTION
This is to prevent using a symlink as the release directory