### PR TITLE
CI: use stable branch for catalog updates and prevent duplicate PRs

### DIFF
--- a/.gitlab/catalog.yml
+++ b/.gitlab/catalog.yml
@@ -22,6 +22,9 @@ catalog-pr-create:
     - ./btfhub -hash-dir .tmp/hash -catalog-json rc-employee-configurations/configs/BTF_DD/btfs.json catalog-update
     - cd rc-employee-configurations
     - |
+      set -x
+      git config --local user.name "dd-btfhub-ebpf-platform[bot]"
+      git config --local user.email "205981682+dd-btfhub-ebpf-platform[bot]@users.noreply.github.com"
       # Define a stable branch for updates
       BRANCH_NAME="btfhub-catalog-update"
       # Checkout the existing branch or create it from main

--- a/.gitlab/catalog.yml
+++ b/.gitlab/catalog.yml
@@ -21,19 +21,27 @@ catalog-pr-create:
     - !reference [.catalog_checkout]
     - ./btfhub -hash-dir .tmp/hash -catalog-json rc-employee-configurations/configs/BTF_DD/btfs.json catalog-update
     - cd rc-employee-configurations
-    - git status
-    - git diff
     - |
-      set -x
-      git config --local user.name "dd-btfhub-ebpf-platform[bot]"
-      git config --local user.email "205981682+dd-btfhub-ebpf-platform[bot]@users.noreply.github.com"
-      BRANCH_NAME="btfs/$(date -u +%Y-%m-%dT%H-%M-%S)"
-      git checkout -b "${BRANCH_NAME}"
+      # Define a stable branch for updates
+      BRANCH_NAME="btfhub-catalog-update"
+      # Checkout the existing branch or create it from main
+      if git ls-remote --exit-code origin "${BRANCH_NAME}"; then
+        git fetch origin "${BRANCH_NAME}:${BRANCH_NAME}"
+        git checkout "${BRANCH_NAME}"
+      else
+        git checkout -b "${BRANCH_NAME}" origin/main
+      fi
       git add -A
       if git diff-index --quiet HEAD; then
         echo "No changes"
+        exit 0
+      fi
+      # Amend the existing commit for a single, up-to-date commit
+      git commit --amend -m "BTF_DD catalog update on $(date -u +%Y-%m-%d)"
+      git push --force origin "${BRANCH_NAME}"
+      # Only create a PR if none is already open for this branch
+      if gh pr list -R DataDog/rc-employee-configurations --head "${BRANCH_NAME}" --state open | grep -q '.'; then
+        echo "PR already open"
       else
-        git commit -m "BTF_DD catalog update on $(date -u +%Y-%m-%d)"
-        git push --set-upstream origin "${BRANCH_NAME}"
-        gh pr create -R DataDog/rc-employee-configurations -B main -f --head $(git branch --show-current)
+        gh pr create -R DataDog/rc-employee-configurations -B main -f --head "${BRANCH_NAME}"
       fi


### PR DESCRIPTION
This change refactors the GitLab CI catalog-pr-create job so that instead of creating a new timestamped branch (and PR) every run, it:
- Defines a single stable branch (btfhub-catalog-update) for all catalog updates
- Checks out that branch if it already exists, or creates it off main otherwise
- Runs git commit --amend and git push --force to keep it up to date
- Guards gh pr create with a lookup of existing open PRs, to avoid opening duplicates

Benefits:
- Eliminates PR spam when the catalog hasn’t actually changed
- Maintains one living PR that automatically reflects any real diffs
- Simplifies cleanup (enable auto-delete on merge or delete the branch once merged)

Notes:
Another option is to hold off on creating new PRs until the existing one is merged. However, doing so means any subsequent catalog changes would be deferred (and potentially missed) while that PR remains open.