### PR TITLE
do not update openSUSE Leap 15.x due to EOL

### DIFF
--- a/.gitlab/btf.yml
+++ b/.gitlab/btf.yml
@@ -73,9 +73,6 @@ btf-generate-direct-x64:
       - DISTRO: ol
         RELEASE: [ "7", "8" ]
         BTF_ARCH: [ x86_64, arm64 ]
-      - DISTRO: opensuse-leap
-        RELEASE: [ "15.0", "15.1", "15.2", "15.3" ]
-        BTF_ARCH: [ x86_64, arm64 ]
       - DISTRO: ubuntu
         RELEASE: [ "16.04", "18.04", "20.04" ]
         BTF_ARCH: [ x86_64, arm64 ]

--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -88,10 +88,6 @@ func GetLinks(ctx context.Context, repoURL string) ([]string, error) {
 
 var linksClient = http.Client{
 	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		// these hosts have URL 404s
-		if strings.HasPrefix(req.URL.String(), "https://slc-mirror.opensuse.org") || strings.HasPrefix(req.URL.String(), "https://provo-mirror.opensuse.org") {
-			req.URL.Host = "mirror-br.opensuse.org"
-		}
 		fmt.Printf("redirect to %s\n", req.URL)
 		return nil
 	},


### PR DESCRIPTION
No mirror has the debug content for these versions anymore