### PR TITLE
increase timeout for Oracle linux

### DIFF
--- a/.gitlab/btf.yml
+++ b/.gitlab/btf.yml
@@ -74,11 +74,21 @@ btf-generate-direct-x64:
       - DISTRO: fedora
         RELEASE: [ "24", "25", "26", "27", "28", "29", "30", "31" ]
         BTF_ARCH: [ x86_64, arm64 ]
-      - DISTRO: ol
-        RELEASE: [ "7", "8" ]
-        BTF_ARCH: [ x86_64, arm64 ]
       - DISTRO: ubuntu
         RELEASE: [ "16.04", "18.04", "20.04" ]
+        BTF_ARCH: [ x86_64, arm64 ]
+
+btf-generate-ol:
+  extends: .btf-generate
+  timeout: 2h
+  tags:
+    - "arch:amd64"
+  variables:
+    IMAGE: ubuntu
+    DISTRO: ol
+  parallel:
+    matrix:
+      - RELEASE: [ "7", "8" ]
         BTF_ARCH: [ x86_64, arm64 ]
 
 btf-generate-amzn-x64:

--- a/.gitlab/btf.yml
+++ b/.gitlab/btf.yml
@@ -80,7 +80,7 @@ btf-generate-direct-x64:
 
 btf-generate-ol:
   extends: .btf-generate
-  timeout: 2h
+  timeout: 3h
   tags:
     - "arch:amd64"
   variables:

--- a/.gitlab/catalog.yml
+++ b/.gitlab/catalog.yml
@@ -6,6 +6,7 @@ catalog-pr-create:
   stage: catalog
   needs:
     - btf-generate-direct-x64
+    - btf-generate-ol
     - btf-generate-amzn-x64
     - btf-generate-rhel-7
     - btf-generate-rhel-8-x64


### PR DESCRIPTION
Just like RHEL it takes longer for BTF generation for these kernels for some reason.